### PR TITLE
Added option to limit pathname length

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -187,6 +187,8 @@ To control whether to split out the path and file name or not, use: >
   let g:bufExplorerSplitOutPathName=1  " Split the path and file name.
   let g:bufExplorerSplitOutPathName=0  " Don't split the path and file
                                        " name.
+  let g:bufExplorerPathNameCount=3     " Display last 3 parts of the filename
+
 The default is to split the path and file name.
 
                                                       *g:bufExplorerSplitRight*

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -673,7 +673,17 @@ function! s:BEBuildBufferList()
         else
             let type = (g:bufExplorerShowRelativePath) ? "relativename" : "fullname"
             let path = buf[type]
-            let line .= path
+
+            if g:bufExplorerPathNameCount
+                let pathArray = split(path, "/")
+                let n = g:bufExplorerPathNameCount
+                while n > 0
+                    let line .= get(pathArray, -n) . "/"
+                    let n = n - 1
+                endwhile
+            else 
+                let line .= path
+            endif 
         endif
 
         let pads = (g:bufExplorerShowUnlisted) ? s:allpads : s:listedpads


### PR DESCRIPTION
The buffer list gets pretty messy if you have files in many subfolders. 

This lets you specify the last ones that are most relevant
