### PR TITLE
fix: fixed the issue where the array index out of range

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -183,7 +183,10 @@ function! s:BEActivateBuffer()
   elseif empty(l) || index(l, b) == -1
     " Add new buffer to this tab buffer list
     let l = add(l, b)
-    let s:tabSpace[tabpagenr()] = l
+
+    if len(s:tabSpace) > tabpagenr()
+      let s:tabSpace[tabpagenr()] = l
+    endif
 
     if g:bufExplorerOnlyOneTab == 1
       " If a buffer can only be available in 1 tab page


### PR DESCRIPTION
i.e. when woking with goyo.vim plugin, when open multiple files, for example:

$ vim *.slide

It reports error:
`
Error detected while processing CursorMoved Autocommands for "<buffer=5>"..function <SNR>109_blank[5]..WinEnter Autocommands for "<buffer=3>"..function <SNR>1
09_blank[5]..BufEnter Autocommands for "*"..function <SNR>34_BEActivateBuffer:
line   20:
E684: list index out of range: 2
`